### PR TITLE
fix: avoid ARG_MAX crash in bake metadata matrix computation

### DIFF
--- a/.github/workflows/standard-build-bake.yaml
+++ b/.github/workflows/standard-build-bake.yaml
@@ -173,9 +173,21 @@ jobs:
 
       - name: Compute image matrix
         id: images
-        env:
-          METADATA: ${{ steps.bake.outputs.metadata }}
+        # bake's metadata output grows with the number of targets built (one full buildx metadata
+        # entry per target) - with enough targets it can reach hundreds of KB. Passing something
+        # that size through `env:` and into a shell variable counts against the OS's ARG_MAX for
+        # the process GitHub Actions spawns to run this step, and fails with "Argument list too
+        # long" once it's large enough. Writing it into a file instead - via a quoted (inert,
+        # non-expanding) heredoc embedded directly in the script body, which GitHub Actions expands
+        # into the script *file* it writes to disk rather than into that process's environment -
+        # sidesteps the limit regardless of target count.
+        # zizmor: ignore[template-injection] the metadata is written into a `<<'EOF'` heredoc, whose
+        # quoted delimiter means the shell treats its content as inert literal text, not code to
+        # execute - unlike an unquoted `${{ }}` interpolated directly into a shell command.
         run: |
+          cat <<'BAKE_METADATA_EOF' > "${RUNNER_TEMP}/bake-metadata.json"
+          ${{ steps.bake.outputs.metadata }}
+          BAKE_METADATA_EOF
           jq -c '
             [
               to_entries[]
@@ -189,7 +201,7 @@ jobs:
                   slug: ((.tags[0] // .target) | gsub("[^a-zA-Z0-9]"; "-")),
                 }
             ]
-          ' <<<"${METADATA}" | tee images.json
+          ' "${RUNNER_TEMP}/bake-metadata.json" | tee images.json
           echo "matrix=$(jq -c . images.json)" >> "$GITHUB_OUTPUT"
 
       - name: Save images as tar archives


### PR DESCRIPTION
## Summary
- `standard-build-bake.yaml`'s "Compute image matrix" step passed `docker/bake-action`'s `metadata` output through an `env:` variable into a shell command substitution (`<<<"${METADATA}"`). That output grows with the number of bake targets - one full buildx metadata entry per target - and environment variables count against the OS's `ARG_MAX` for the process GitHub Actions spawns to run a step's script. A large enough bake file (11 targets, in this case) pushes the combined environment over that limit and the step fails immediately with `Argument list too long`, before its script even runs.
- Fix: write the metadata into a file via a quoted (`<<'EOF'`) heredoc embedded directly in the script body, instead of via `env:`. GitHub Actions expands `${{ }}` expressions into the *script file* it writes to disk for a `run:` step, not into that process's environment - so this sidesteps `ARG_MAX` regardless of target count. The quoted delimiter keeps the substituted content inert literal text rather than executable shell, which is what preserves the injection-safety `env:` was providing in the first place (documented inline, with a `zizmor: ignore[template-injection]` explaining why the usual `env:` pattern doesn't apply here).

## Context
Surfaced by [miracum/recruit](https://github.com/miracum/recruit)'s migration to a single bake file covering 4 Java modules + list/list-next (11 targets total, including `*-test` build-gate variants) - `docker/bake-action`'s metadata output for that many targets came out to ~292KB of compact JSON, which was enough to crash this step on every run once the build itself (previously the bottleneck) got fast enough to actually reach it.

## Test plan
- [x] `python3 -c "import yaml; ..."` - workflow YAML parses
- [x] `uvx zizmor .github/workflows/standard-build-bake.yaml` - clean, no findings
- [x] Reconstructed the actual ~292KB metadata payload from the real failing run's logs (11 targets: query/notify/list/list-next/query-sql-on-fhir/superset-library-sync + their `*-test` variants) and a synthetic same-shape payload, and confirmed the fixed heredoc → file → `jq` pipeline produces the identical matrix output as the original `env:`-based version, just without the crash
- [ ] Confirm in a real recruit CI run once this merges