### PR TITLE
fix: exclude *-test build-gate targets from the images output

### DIFF
--- a/.github/workflows/standard-build-bake.yaml
+++ b/.github/workflows/standard-build-bake.yaml
@@ -45,6 +45,18 @@ on:
         required: false
         default: true
         type: boolean
+      exclude-targets-pattern:
+        description: >-
+          Extended regex matched against each bake target's key. Matching targets are still built
+          (so e.g. a Dockerfile `test` stage still runs as a build-time gate), but are excluded from
+          the `images` output and therefore from the trivy scan/SBOM, signing, provenance
+          attestation, and the uploaded `images` artifact - none of which make sense for a target
+          that's never actually published/deployed. Defaults to this workflow's own documented
+          build-gate convention (see the `app`/`app-test` example bake file); set to an empty string
+          to disable filtering and include every built target.
+        required: false
+        default: '-test$'
+        type: string
       trivy-ignore-unfixed:
         description: "Ignore unfixed/unfixable vulnerabilities in reports"
         required: false
@@ -65,9 +77,9 @@ on:
       images:
         value: ${{ jobs.build.outputs.images }}
         description: >-
-          JSON array with one entry per image built by bake, each with the
-          keys `target` (the bake target name), `name` (image name without
-          tag), `tags` (array of tags), `digest`, and `slug` (a
+          JSON array with one entry per image built by bake and not excluded by
+          `exclude-targets-pattern`, each with the keys `target` (the bake target name), `name`
+          (image name without tag), `tags` (array of tags), `digest`, and `slug` (a
           filesystem/artifact-name-safe version of the first tag, also used
           as the `<slug>.tar` filename inside the `images` artifact when
           `enable-upload-image` is set).
@@ -184,13 +196,16 @@ jobs:
         # zizmor: ignore[template-injection] the metadata is written into a `<<'EOF'` heredoc, whose
         # quoted delimiter means the shell treats its content as inert literal text, not code to
         # execute - unlike an unquoted `${{ }}` interpolated directly into a shell command.
+        env:
+          EXCLUDE_TARGETS_PATTERN: ${{ inputs.exclude-targets-pattern }}
         run: |
           cat <<'BAKE_METADATA_EOF' > "${RUNNER_TEMP}/bake-metadata.json"
           ${{ steps.bake.outputs.metadata }}
           BAKE_METADATA_EOF
-          jq -c '
+          jq -c --arg pattern "${EXCLUDE_TARGETS_PATTERN}" '
             [
               to_entries[]
+              | select(($pattern | length) == 0 or (.key | test($pattern) | not))
               | {
                   target: .key,
                   digest: .value["containerimage.digest"],


### PR DESCRIPTION
## Summary
- Every downstream stage of this workflow (trivy scan/SBOM generation, signing, build provenance attestation, and the uploaded `images` artifact) iterates over the `images` output computed by "Compute image matrix". That output previously included *every* bake target unconditionally - including this workflow's own documented `*-test` build-gate convention (the `app`/`app-test` example bake file bundled with this workflow). Those targets exist purely to run a Dockerfile `test` stage as a build-time gate and are never published/deployed, so scanning, signing, and attesting them was pure waste - one that scales linearly with target count.
- Adds a new `exclude-targets-pattern` input (extended regex matched against each target's bake key, default `-test$` matching the existing convention, empty string to disable) and applies it once in "Compute image matrix" via jq's `test()`. Since every downstream job derives its matrix from this same `images` output, this is a single filter point rather than needing to patch each consumer separately. Excluded targets are still *built* (the `bake-targets`/default group is unaffected) - only the post-build pipeline (scan/sign/attest/upload) skips them, so the build-gate itself still runs and still fails the job if tests fail.

## Context
Follow-up to #194. Reported from [miracum/recruit](https://github.com/miracum/recruit): its 11-target bake file (4 Java modules + list/list-next, each with a `*-test` build-gate variant per module that has a Dockerfile `test` stage) was getting all 11 images trivy-scanned, roughly doubling scan time and noise for images nobody ever pulls.

## Test plan
- [x] `python3 -c "import yaml; ..."` - workflow YAML parses
- [x] `uvx zizmor .github/workflows/standard-build-bake.yaml` - clean, no findings
- [x] Ran the updated jq filter against a synthetic 11-target metadata payload (same shape as recruit's real one): default pattern correctly drops the 5 `*-test` entries, leaving the 6 real ones; empty pattern leaves all 11 (backward compatible)
- [ ] Confirm in a real recruit CI run once this merges and recruit bumps its pin