### PR TITLE
fix: set standard OCI labels on bake-built images

### DIFF
--- a/.github/workflows/standard-build-bake.yaml
+++ b/.github/workflows/standard-build-bake.yaml
@@ -152,6 +152,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.github-token }}
 
+      # standard-build.yaml gets its standard OCI labels (source, revision, licenses, ...) for free
+      # from docker/metadata-action's `labels` output, fed straight into docker/build-push-action's
+      # `labels:` input. bake has no equivalent single-image `labels:` input - it builds many
+      # differently-named targets in one invocation - so the same labels are instead applied to
+      # every target uniformly via `*.labels.<key>=<value>` --set overrides below. The `images:`
+      # value here is only ever used to derive those repo-level labels (title, source, licenses,
+      # revision, created, ...), never for tags/pushing - bake targets define their own tags/names
+      # in the bake file itself.
+      - name: Container image meta
+        id: image_meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Convert image labels to bake --set overrides
+        id: bake_labels
+        env:
+          LABELS: ${{ steps.image_meta.outputs.labels }}
+        run: |
+          {
+            echo "set<<BAKE_LABEL_SET_EOF"
+            while IFS= read -r label; do
+              [ -n "${label}" ] && echo "*.labels.${label}"
+            done <<< "${LABELS}"
+            echo "BAKE_LABEL_SET_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       # pull_request builds (from a fork or not) are never pushed to the
       # registry: they're loaded into the local docker daemon instead, so
       # they can still be scanned by trivy below and, if enabled, saved as
@@ -177,6 +204,7 @@ jobs:
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
             *.output=${{ github.event_name != 'pull_request' && 'type=image,push=true,oci-mediatypes=true,compression=zstd,force-compression=true' || 'type=docker' }}
+            ${{ steps.bake_labels.outputs.set }}
             ${{ inputs.bake-set }}
 
       - name: display images


### PR DESCRIPTION
## Summary
- `standard-build.yaml` gets its standard OCI labels (`org.opencontainers.image.source`, `.revision`, `.licenses`, `.created`, etc.) for free from `docker/metadata-action`'s `labels` output, fed straight into `docker/build-push-action`'s `labels:` input. `standard-build-bake.yaml` never had an equivalent - `docker/bake-action` has no single-image `labels:` input at all, since one bake invocation builds many differently-named/tagged targets - so every image built through this workflow ended up with **no** standard OCI labels whatsoever.
- Adds a `docker/metadata-action` step, using `ghcr.io/<repo>` purely to derive the repo-level labels (title, source, licenses, revision, created, ...) - never for tags/pushing, since bake targets already define their own tags/names in the bake file - and converts its `labels` output into `*.labels.<key>=<value>` `--set` overrides, applied to every built target the same way `*.platform`/`*.cache-from`/etc. already are.

## Context
Reported from [miracum/recruit](https://github.com/miracum/recruit): its container-structure-tests started failing with `label org.opencontainers.image.licenses not found in image metadata` once its build moved from `standard-build.yaml` to this workflow, since bake-built images had no OCI labels at all.

## Test plan
- [x] `python3 -c "import yaml; ..."` - workflow YAML parses
- [x] `uvx zizmor .github/workflows/standard-build-bake.yaml` - clean, no findings
- [x] Built a real target (`superset-library-sync`) from recruit's actual `docker-bake.hcl` locally, with a realistic `docker/metadata-action`-shaped labels payload run through the new conversion step, and confirmed `docker inspect` shows all 8 standard OCI labels on the resulting image, including `org.opencontainers.image.licenses`
- [ ] Confirm in a real recruit CI run once this merges and recruit bumps its pin