### PR TITLE
fix: scope GHA cache to each built image

### DIFF
--- a/.github/workflows/standard-build.yaml
+++ b/.github/workflows/standard-build.yaml
@@ -234,8 +234,8 @@ jobs:
           outputs: type=oci,dest=./image-test.tar,oci-mediatypes=true,compression=zstd,force-compression=true
           tags: ${{ steps.tests_image_meta.outputs.tags }}
           labels: ${{ steps.tests_image_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
           target: test
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
@@ -278,8 +278,8 @@ jobs:
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || false }}
           tags: ${{ steps.image_meta.outputs.tags }}
           labels: ${{ steps.image_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
 


### PR DESCRIPTION
## Summary

- `cache-from: type=gha` / `cache-to: type=gha,mode=max` never set a `scope=`, so both fall back to buildkit's own default scope, the literal string `"buildkit"` (see [gha.go](https://github.com/moby/buildkit/blob/master/cache/remotecache/gha/gha.go)) - one global cache namespace shared across *every* build that uses this workflow, regardless of which image or Dockerfile.
- That was harmless while builds effectively serialized, but with multiple concurrent `standard-build.yaml` callers (e.g. several jobs building different images in the same CI run), separate buildkitd instances on separate runners now race to read/write that same scope at once.
- Observed in [miracum/recruit#642](https://github.com/miracum/recruit/pull/642): builds that had already succeeded and pushed their image died afterwards at the cache-export step:
  ```
  #22 exporting to GitHub Actions Cache
  #22 preparing build cache for export
  ERROR: failed to build: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF
  ```
  Consistent and reproducible across concurrent jobs, regardless of Dockerfile cache-mount size - only stopped once each job's `type=gha` scope was made unique.

## Fix

Scope both the test-layer and main build's `cache-from`/`cache-to` to `inputs.image`, which is already unique per workflow call. Unrelated concurrent builds (different images) no longer contend for the same GHA cache scope; sequential builds for the *same* image (test-layer build, then main build) keep sharing a scope, so they still benefit from each other's cache.

## Test plan

- [x] YAML validated locally
- [ ] Exercise via a caller repo (e.g. rerun the recruit#642 CI) to confirm the `rpc error: code = Unavailable` failures stop recurring