### PR TITLE
fix: switch build cache backend from gha to registry

### DIFF
--- a/.github/workflows/standard-build.yaml
+++ b/.github/workflows/standard-build.yaml
@@ -234,8 +234,8 @@ jobs:
           outputs: type=oci,dest=./image-test.tar,oci-mediatypes=true,compression=zstd,force-compression=true
           tags: ${{ steps.tests_image_meta.outputs.tags }}
           labels: ${{ steps.tests_image_meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ inputs.image }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
+          cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
+          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
           target: test
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
@@ -278,8 +278,8 @@ jobs:
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || false }}
           tags: ${{ steps.image_meta.outputs.tags }}
           labels: ${{ steps.image_meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ inputs.image }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
+          cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
+          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
 


### PR DESCRIPTION
## Summary

- #199 scoped `type=gha`'s `cache-from`/`cache-to` to `inputs.image` to stop unrelated concurrent builds (different images) from colliding on the shared default `"buildkit"` scope.
- That's still correct, but it wasn't sufficient: reported against [miracum/recruit#642](https://github.com/miracum/recruit/pull/642), the same failure kept recurring even after the per-image scope landed and after disabling `enable-buildkit-cache-mount-caching` entirely:
  ```
  #22 exporting to GitHub Actions Cache
  #22 preparing build cache for export
  ERROR: failed to build: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF
  ```
  Consistently reproducible with several `standard-build.yaml` jobs running concurrently in one workflow run (multiple images, each doing its own test-layer + main build against `type=gha`) - the image build and push themselves complete fine every time; only the trailing cache export dies.

## Fix

Switch both the test-layer and main build's `cache-from`/`cache-to` from `type=gha` to `type=registry`, storing the build cache as ordinary layers pushed/pulled from the same registry the image itself is pushed to (ghcr.io) instead of going through the GitHub Actions Cache API. A registry is built for concurrent push/pull at scale; the Actions Cache backend apparently isn't holding up under this workflow's level of concurrency.

- Both build steps share one `<inputs.image>:buildcache` ref, so the (sequential, same-job) main build gets to import the test-layer build's cache for free.
- `cache-to` is gated behind the same same-repo-PR-or-non-PR check already used for the image push `outputs:` entry, since forked PRs never authenticate to the registry and would otherwise fail trying to push the cache blob.
- `cache-from` is left unconditional - a missing/unauthenticated cache pull is a soft no-op for buildx, not a hard failure.

## Test plan

- [x] YAML validated locally
- [ ] Exercise via recruit#642's CI to confirm the `rpc error: code = Unavailable` failures stop recurring