### PR TITLE
fix: export build cache with mode=min instead of mode=max

### DIFF
--- a/.github/workflows/standard-build.yaml
+++ b/.github/workflows/standard-build.yaml
@@ -235,7 +235,7 @@ jobs:
           tags: ${{ steps.tests_image_meta.outputs.tags }}
           labels: ${{ steps.tests_image_meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
-          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=min', inputs.image) || '' }} # zizmor: ignore[template-injection]
           target: test
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
@@ -279,7 +279,7 @@ jobs:
           tags: ${{ steps.image_meta.outputs.tags }}
           labels: ${{ steps.image_meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
-          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=min', inputs.image) || '' }} # zizmor: ignore[template-injection]
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
 


### PR DESCRIPTION
## Summary

Follow-up to #200. `mode=max` exports cache for every layer in the build graph, including ones that never end up in the final image. For a Dockerfile like recruit's, where a builder stage (full JDK + every resolved dependency, easily gigabytes) feeds a tiny distroless final image purely via `COPY --from=`, `mode=max` on the main build means pushing nearly the whole builder image as cache blobs on every single build - wasteful and slow regardless of which cache backend is used, and a plausible contributor to the export instability #200 worked around by moving off `type=gha`.

## Fix

`cache-to` for both the test-layer and main build now uses `mode=min`: only layers reachable from the actual build output get cached.

- The test-layer build's output *is* the full builder chain (multi-stage, linear `FROM` up to `test`), so its cache stays exactly as complete as before.
- The main build's export shrinks to just what isn't already covered by the test-layer build's export to the same `<image>:buildcache` ref - re-exporting that same content there with `mode=max` was redundant to begin with.

`cache-from` is untouched; `mode` only affects what gets exported, not what can be imported.

## Test plan

- [x] YAML validated locally
- [ ] Exercise via recruit#642's CI once #200 (registry backend) is confirmed working, to check cache-export time/size drops without losing cache-hit coverage