### PR TITLE
feat: make registry build cache disable-able

### DIFF
--- a/.github/workflows/standard-build.yaml
+++ b/.github/workflows/standard-build.yaml
@@ -76,6 +76,11 @@ on:
         required: false
         default: false
         type: boolean
+      enable-build-cache:
+        description: "If enabled, caches image layers across builds by pushing/pulling a `<image>:buildcache` tag to/from the same registry the built image itself is pushed to. Disable for Dockerfiles that get more value from enable-buildkit-cache-mount-caching than from layer caching, to skip the extra registry round-trip."
+        required: false
+        default: true
+        type: boolean
     outputs:
       image-tags:
         value: ${{ jobs.build.outputs.image-tags }}
@@ -234,8 +239,8 @@ jobs:
           outputs: type=oci,dest=./image-test.tar,oci-mediatypes=true,compression=zstd,force-compression=true
           tags: ${{ steps.tests_image_meta.outputs.tags }}
           labels: ${{ steps.tests_image_meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
-          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-from: ${{ inputs.enable-build-cache && format('type=registry,ref={0}:buildcache', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-to: ${{ inputs.enable-build-cache && (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
           target: test
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
@@ -278,8 +283,8 @@ jobs:
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || false }}
           tags: ${{ steps.image_meta.outputs.tags }}
           labels: ${{ steps.image_meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ inputs.image }}:buildcache # zizmor: ignore[template-injection]
-          cache-to: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-from: ${{ inputs.enable-build-cache && format('type=registry,ref={0}:buildcache', inputs.image) || '' }} # zizmor: ignore[template-injection]
+          cache-to: ${{ inputs.enable-build-cache && (github.event_name != 'pull_request' || (github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name)) && format('type=registry,ref={0}:buildcache,mode=max', inputs.image) || '' }} # zizmor: ignore[template-injection]
           platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
 


### PR DESCRIPTION
## Summary

Follow-up to #200 (closes out #201, which tried `mode=min` for the same underlying concern - keeping `mode=max` here instead).

Not every caller's Dockerfile benefits from the `<image>:buildcache` registry cache the same way. One that already relies on `enable-buildkit-cache-mount-caching` for its expensive part (e.g. a package manager's download cache, persisted via `RUN --mount=type=cache`) gets comparatively little from *also* layer-caching the whole build through a second registry round-trip on every push/pull - just extra latency and registry traffic for marginal benefit, reported from [miracum/recruit#642](https://github.com/miracum/recruit/pull/642).

## Change

Adds `enable-build-cache` (default `true`, so existing callers keep today's behavior unchanged) gating both `cache-from` and `cache-to`. Set to `false` for a build that's better served by `enable-buildkit-cache-mount-caching` alone.

## Test plan

- [x] YAML validated locally
- [ ] Exercise via recruit#642's CI with `enable-build-cache: false` + `enable-buildkit-cache-mount-caching: true` on its Java module jobs